### PR TITLE
[IMP] multi : _company , _website user config acceess

### DIFF
--- a/maqabim_website_popup/__init__.py
+++ b/maqabim_website_popup/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+
+from . import models
+

--- a/maqabim_website_popup/__manifest__.py
+++ b/maqabim_website_popup/__manifest__.py
@@ -15,7 +15,7 @@ Maqabim Website Popup
 * This website may contain smoking and smoking alternative products.
     """,
     'category': 'Custom Development',
-    'depends': ['website'],
+    'depends': ['website', 'website_multi'],
     'data': [
         'views/website_template.xml',
     ],

--- a/maqabim_website_popup/models/__init__.py
+++ b/maqabim_website_popup/models/__init__.py
@@ -1,0 +1,3 @@
+# coding: utf-8
+
+from . import res_config_settings

--- a/maqabim_website_popup/models/res_config_settings.py
+++ b/maqabim_website_popup/models/res_config_settings.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+
+    @api.model
+    def get_values(self):
+        res = super(ResConfigSettings, self).get_values()
+        # website does not have any record rule so when user load website >setting 
+        # it pull fiest website and related fields i.e. website_user_id and website_template_user_id 
+        # and user may not access to such details as first website company may not be alloweded
+        # incase of multi company, we will try to load websitre of his current company allowing
+        # Website>setting to load and then user can chage to any allowded companies or users.
+        user_company_websites = self.env['website'].search([('company_id', '=', self.env.user.company_id.id)])
+        if user_company_websites:
+            res.update({'website_id': user_company_websites.id})
+        return res


### PR DESCRIPTION
 The model `website` does not have any record rule so when user load Website > Settings  it pull first website and related fields i.e. `website_user_id` and `website_template_user_id`  and the user may not access to such details as the first website company may not be allowed  in case of multi-company, we will try to load the website of his current company allowing  Website>setting to load and then the user can change to any allowed companies or users.