### PR TITLE
[FIX]  bug in custom print report dev

### DIFF
--- a/maqabim_purchase/models/sale.py
+++ b/maqabim_purchase/models/sale.py
@@ -18,3 +18,16 @@ class SaleOrderLine(models.Model):
             vals['print_qty'] = int(vals['product_uom_qty'])
         res = super(SaleOrderLine, self).create(vals)
         return res
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.multi
+    def _cart_update(self, product_id=None, line_id=None, add_qty=0, set_qty=0, attributes=None, **kwargs):
+        """ Add or set product quantity, add_qty can be negative """
+        order_line_vals = super(SaleOrder, self)._cart_update(product_id=product_id, line_id=line_id, add_qty=add_qty, set_qty=set_qty, attributes=attributes, **kwargs)
+        SaleOrderLineSudo = self.env['sale.order.line'].sudo()
+        order_line = SaleOrderLineSudo.browse(order_line_vals['line_id'])
+        order_line.write({'print_qty': order_line_vals['quantity']})
+        return order_line_vals


### PR DESCRIPTION
Exact use case where we experience the issue
> A sales order comes in through the website
> Initial print qty = 1 instead of print qty = ordered qty
Video made by the client to demonstrate: https://drive.google.com/file/d/1n_6WiD2TeWnQSUvXHld309RkVC-Pw-JJ/view?usp=sharing

PSUSMaintnance#2027759

Co-authored-by: Darshan Kalola <dka@odoo.com>